### PR TITLE
Event object

### DIFF
--- a/lib/meteor-stubs.js
+++ b/lib/meteor-stubs.js
@@ -74,8 +74,8 @@ var Npm, Deps, Package, Random, Session, Template, Meteor, Handlebars;
                         TemplateClass.prototype[helper] = helperMap[helper];
                     }
                 },
-                fireEvent: function (key) {
-                    TemplateClass.prototype.eventMap[key]();
+                fireEvent: function (key, event) {
+                    TemplateClass.prototype.eventMap[key](event);
                 },
                 // Allows you to set an attribute in the event 'this' context
                 addContextAttribute: function (key, value) {


### PR DESCRIPTION
I needed the event.which in a template, so I passed an event param. 

I use like this:

``` javascript
Template.entryfield.fireEvent("keydown #message", {which: 13});
```
