### PR TITLE
Add Meteor.users = new Meteor.Collection('users')

### DIFF
--- a/lib/meteor-stubs.js
+++ b/lib/meteor-stubs.js
@@ -43,7 +43,10 @@ var Npm, Deps, Package, Random, Session, Template, Handlebars, Accounts, Meteor,
         allow: emptyFunction,
         deny: emptyFunction
     };
-
+    
+    // instanciate the users collection, which is just a collection but always created in the Meteor object
+    Meteor.users = new Meteor.Collection('users');
+    
     Meteor.autorun = function (func) {
         func();
     };


### PR DESCRIPTION
Although this is very easy to do with project specific stubs, I think it's good to have `Meteor.users = new Meteor.Collection('users')` as part of `meteor-stubs.js` since Meteor.users is a collection created by Meteor automatically, so it's less of a "surprise factor" for noobs (such as admittedly - myself)
