### PR TITLE
When the test runnner starts - run all tests (don't wait for file changes)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,6 +23,7 @@
         tasks.push('bgShell:startMirrorApp');
         tasks.push('bgShell:startKarma');
         tasks.push('bgShell:startApp');
+        tasks.push('runOnce');
         tasks.push('outputPorts');
         tasks.push('watch');
         return tasks;
@@ -44,9 +45,15 @@
         return tasks;
     };
 
-    var startupTasks = constructStartupTasks(),
-        watchTasks = constructWatchTasks();
+    var constructRunOnceTasks = function() {
+        var tasks = constructWatchTasks();
+        tasks.unshift('bgShell:sleep');
+        return tasks;
+    };
 
+    var startupTasks = constructStartupTasks(),
+        watchTasks = constructWatchTasks(),
+        runOnce = constructRunOnceTasks();
 
     function getLatestCoverageObject() {
         var coverageDir = PROJECT_BASE_PATH + '/build/reports/coverage';
@@ -323,6 +330,10 @@
                     cmd: 'touch <%= basePath %>/build/mirror_app/.meteor/packages;',
                     bg: false,
                     fail: false
+                },
+                sleep: {
+                    cmd: 'echo; echo "Sleeping some to wait for browser to start"; echo; sleep 2; open http://localhost:9876/; sleep 2',
+                    bg: false
                 }
             },
             'unzip': {
@@ -381,6 +392,7 @@
             console.log('Launching Mirror on port 8000');
         });
 
+        grunt.registerTask('runOnce', 'runOnce', runOnce);
         grunt.registerTask('default', startupTasks);
 
     };


### PR DESCRIPTION
When I run rtd I think it should first run all tests and then wait for file changes (to run again).
I implemented this, but not sure if it's a perfect solution. It works but with caveats. 
One problem I see with it is that it'd open a new browser window at http://localhost:9876/ every time it's run (so if I run rtd a few times the browser tabs start to pile up).
Another possible issue is that I found out I have to wait for the browser to be ready (so I added a sleep) and before that I have to wait for karma to be ready (so I added another sleep). These sleep statements could very easily become incorrect, as everything that depends on timing does. But I haven't found another solution for being able to wait for karma and then wait for the browser. 
Anyway, it's a sketch for a solution, let me know what you think. 
