### PR TITLE
Stub for Meteor.require

### DIFF
--- a/lib/meteor-npm-stubs.js
+++ b/lib/meteor-npm-stubs.js
@@ -1,0 +1,9 @@
+// Stubs for the npm package
+
+(function () {
+    "use strict";
+
+    Meteor.require = function(module) {
+        return {};
+    };
+})();


### PR DESCRIPTION
Stubs for the `Meteor.require` method provided by [meteor-npm](https://github.com/arunoda/meteor-npm)
