### PR TITLE
Add share object to the Meteor stub to cater for coffeescript projects

### DIFF
--- a/lib/meteor-stubs.js
+++ b/lib/meteor-stubs.js
@@ -1,5 +1,5 @@
 /*jshint -W020, -W079 */
-var Npm, Deps, Package, Random, Session, Template, Handlebars, Accounts, Meteor, process, __meteor_bootstrap__;
+var Npm, Deps, Package, Random, Session, Template, Handlebars, Accounts, Meteor, process, __meteor_bootstrap__, share;
 
 (function () {
     "use strict";
@@ -223,5 +223,7 @@ var Npm, Deps, Package, Random, Session, Template, Handlebars, Accounts, Meteor,
     process = {
         env: {}
     };
+
+	share = {};
 
 })();


### PR DESCRIPTION
Adds a "share" object to the Meteor stub to cater for coffeescript projects that make use of the "share" global that Meteor makes available (http://docs.meteor.com/#coffeescript). See https://github.com/xolvio/meteor-rtd-example-project/issues/28
