### PR TITLE
Point to latest Chromedriver downloads URL

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -359,7 +359,7 @@
             },
             'unzip': {
                 chromeDriver: {
-                    src: '<%= basePath %>/test/rtd/lib/bin/<%= chromeDriverName %>_<%= chromeDriverOs %>_<%= chromeDriverVersion %>.zip',
+                    src: '<%= basePath %>/test/rtd/lib/bin/<%= chromeDriverName %>_<%= chromeDriverOs %>.zip',
                     dest: '<%= basePath %>/test/rtd/lib/bin/'
                 }
             },

--- a/lib/selenium-launcher.js
+++ b/lib/selenium-launcher.js
@@ -12,22 +12,25 @@
         EventEmitter = require('events').EventEmitter,
         util = require('util');
 
-    var seleniumServerVersion, seleniumServerSha, seleniumServerFilename, seleniumServerUrl, seleniumServerOutputFile,
-        chromeDriverName, chromeDriverOs, chromeDriverVersion, chromeDriverSha, chromeDriverFilename, chromeDriverUrl, chromeDriverOutFile, chromeDriverExecutable;
+    var seleniumServerLocation, seleniumServerVersion, seleniumServerSha, seleniumServerFilename, seleniumServerUrl, seleniumServerOutputFile,
+        chromeDriverLocation, chromeDriverName, chromeDriverOs, chromeDriverVersion, chromeDriverSha, chromeDriverFilename, chromeDriverUrl, chromeDriverOutFile, chromeDriverExecutable;
 
     function init(options) {
+        chromeDriverLocation = 'http://chromedriver.storage.googleapis.com/';
         chromeDriverName = options.chromeDriverName;
         chromeDriverOs = options.chromeDriverOs;
         chromeDriverVersion = options.chromeDriverVersion;
         chromeDriverSha = options.chromeDriverSha;
+
+        seleniumServerLocation = 'http://selenium.googlecode.com/files/';
         seleniumServerVersion = options.seleniumServerVersion;
         seleniumServerSha = options.seleniumServerSha;
 
         seleniumServerFilename = 'selenium-server-standalone-' + seleniumServerVersion + '.jar',
-            seleniumServerUrl = 'http://selenium.googlecode.com/files/' + seleniumServerFilename,
+            seleniumServerUrl = seleniumServerLocation + seleniumServerFilename,
             seleniumServerOutputFile = path.join(path.dirname(__filename), '/bin/' + seleniumServerFilename),
-            chromeDriverFilename = chromeDriverName + '_' + chromeDriverOs + '_' + chromeDriverVersion + '.zip',
-            chromeDriverUrl = 'http://chromedriver.googlecode.com/files/' + chromeDriverFilename,
+            chromeDriverFilename = chromeDriverName + '_' + chromeDriverOs + '.zip',
+            chromeDriverUrl = chromeDriverLocation + chromeDriverVersion + '/' + chromeDriverFilename,
             chromeDriverOutFile = path.join(path.dirname(__filename), '/bin/' + chromeDriverFilename),
             chromeDriverExecutable = path.join(path.dirname(__filename), '/bin/chromedriver');
     }

--- a/rtd.conf.js
+++ b/rtd.conf.js
@@ -46,10 +46,10 @@ module.exports = {
     selenium: {
         // You can set specific versions of selenium-server / chromedriver to use here
         darwin: {
-            chromeDriverName: 'chromedriver2',
+            chromeDriverName: 'chromedriver',
             chromeDriverOs: 'mac32',
-            chromeDriverVersion: '0.8',
-            chromeDriverSha: '5a485bb73a7e85a063cffaab9314837a00b98673'
+            chromeDriverVersion: '2.6',
+            chromeDriverSha: '4643652d403961dd9a9a1980eb1a06bf8b6e9bad'
         },
         linux: {
             chromeDriverName: 'chromedriver',


### PR DESCRIPTION
This updates the Chrome Driver location and changes the default version to 2.6.

I ran into this issue when attempting to run RTD with Chrome 33.0.1707.0 dev

It seems to be compatible with older versions of Chrome and I could not locate `chromedriver2` anywhere on the internet. From what I can tell Chromedriver 2.x is the stable 1.0 release of `chromedriver2`, but please let me know if that's incorrect and `chromedriver2` needs to continue to be used for another reason.
