### PR TITLE
Tell jshint to ignore the packages directory

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -366,7 +366,7 @@
             'jshint': {
                 app: {
                     options: rtdConf.options.jshint && rtdConf.options.jshint.appOptions ? rtdConf.options.jshint.appOptions : {},
-                    src: ['<%= basePath %>/app/**/*.js', '!<%= basePath %>/app/.meteor/**/*.js']
+                    src: ['<%= basePath %>/app/**/*.js', '!<%= basePath %>/app/.meteor/**/*.js', '!<%= basePath %>/app/packages/**/*.js']
                 },
                 test: {
                     options: rtdConf.options.jshint && rtdConf.options.jshint.testOptions ? rtdConf.options.jshint.testOptions : {},


### PR DESCRIPTION
Currently jshint doesn't ignore the packages directory. This means that jshint fails on some meteorite packages 'cause they don't meet the jshint style guide. This pull request changes the gruntfile so that jshint ignores the packages directory.
