### PR TITLE
Exclude our karma and rtd config override files from jshint.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -370,7 +370,7 @@
                 },
                 test: {
                     options: rtdConf.options.jshint && rtdConf.options.jshint.testOptions ? rtdConf.options.jshint.testOptions : {},
-                    src: ['<%= basePath %>/test/**/*.js', '!<%= basePath %>/test/rtd/**/*.js']
+                    src: ['<%= basePath %>/test/**/*.js', '!<%= basePath %>/test/rtd/**/*.js', '!<%= basePath %>/test/rtd.conf.js', '!<%= basePath %>/test/karma.conf.js']
                 }
             },
             cucumberjs: rtdConf.options.cucumberjs ? rtdConf.options.cucumberjs : {}


### PR DESCRIPTION
I'm using rtd's convenient ability to pickup locally modified copies of karma.conf.js and rtd.conf.js from the parent directory. However, the default jshint rules barf on these two files. This PR excludes these two files from jshint.
