### PR TITLE
Simulate meteor's "load files in subdirectories before files in parent directories" load order rule.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,17 +24,41 @@ module.exports = function(config){
             'app/models/**/*.js',
             'app/models/**/*.coffee',
 
-            // simulate loading order of meteor folder structure
-            'app/lib/**/*.js',
-            'app/lib/**/*.coffee',
-            'app/client/lib/**/*.js',
-            'app/client/lib/**/*.coffee',
-            'app/server/lib/**/*.js',
-            'app/server/lib/**/*.coffee',
+	        // simulate meteor's load order rules:
+	        // - lib directory first
+	        // - deeper directories ahead of shallower ones
+	        // we don't currently handle the other meteor load order rule:
+	        // - main.js files after everything else
+	        'app/lib/*/*/*.js',
+	        'app/lib/*/*.js',
+	        'app/lib/**/*.js',
+	        'app/lib/*/*/*.coffee',
+	        'app/lib/*/*.coffee',
+	        'app/lib/**/*.coffee',
 
-            // now all the dependencies have been sorted, the app code can be loaded
-            'app/**/*.js',
-            'app/**/*.coffee'
+	        'app/client/lib/*/*/*.js',
+	        'app/client/lib/*/*.js',
+	        'app/client/lib/**/*.js',
+	        'app/client/lib/*/*/*.coffee',
+	        'app/client/lib/*/*.coffee',
+	        'app/client/lib/**/*.coffee',
+
+	        'app/server/lib/*/*/*.js',
+	        'app/server/lib/*/*.js',
+	        'app/server/lib/**/*.js',
+	        'app/server/lib/*/*/*.coffee',
+	        'app/server/lib/*/*.coffee',
+	        'app/server/lib/**/*.coffee',
+
+	        // now all the dependencies have been sorted, the app code can be loaded
+	        'app/*/*/*/*.js',
+	        'app/*/*/*.js',
+	        'app/*/*.js',
+	        'app/**/*.js',
+	        'app/*/*/*/*.coffee',
+	        'app/*/*/*.coffee',
+	        'app/*/*.coffee',
+	        'app/**/*.coffee'
 
         ],
 


### PR DESCRIPTION
Meteor's load order loads files in subdirectories before files in parent directories. This PR changes rtd to do the same. 

They way I've done it is a bit clunky however, so perhaps someone more experienced with grunt & karma may be able to suggest a better approach:
- it will only deal with directory structures a couple of layers deep;
- I couldn't figure out how to get it to respect the other meteor load order rule, where "files that match main.\* are loaded after everything else".
