### PR TITLE
Use local versions of karma, istanbul, etc instead of global

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "test runner"
   ],
   "dependencies": {
+    "karma": "~0.10",
+    "istanbul": "0.1.39",
+    "jasmine-node": "",
+    "phantomjs": "1.9.0-6",
     "selenium-webdriver": "2.33.0"
   },
   "devDependencies": {
@@ -39,7 +43,6 @@
     "growl": "~1.7.0",
     "libnotify": "~1.0.4",
     "grunt-contrib-coffee": "~0.7.0",
-    "karma": "~0.10",
     "karma-coverage": "~0.1",
     "karma-phantomjs-launcher": "~0.1",
     "karma-junit-reporter": "~0.1",

--- a/rtd
+++ b/rtd
@@ -2,10 +2,12 @@
 
 ulimit -n 4096
 
+NPM_BIN_PATH=$(cd `dirname $0`/node_modules/.bin; echo $PWD)
+
 if [ "$1" = "--debug" ]; then
     npm install;
-    grunt --debug;
+    PATH=$NPM_BIN_PATH:$PATH grunt --debug;
 else
     npm --silent install;
-    grunt;
+    PATH=$NPM_BIN_PATH:$PATH grunt;
 fi


### PR DESCRIPTION
Thought it might be helpful if RTD users weren't required to install karma, istanbul, jasmine-node, phantomjs, and selenium-webdriver globally, especially since specific versions of some of these are apparently required. This patch will cause the executables for these packages to be installed local to RTD and the PATH to be updated when the rtd script is run.
