### PR TITLE
Update meteor-stubs.js

### DIFF
--- a/lib/meteor-stubs.js
+++ b/lib/meteor-stubs.js
@@ -57,6 +57,7 @@ var Npm, Deps, Package, Random, Session, Template, Handlebars, Accounts, Meteor,
         find: function () {
             return {
                 fetch: emptyFunction,
+                observe: emptyFunction,
                 observeChanges: emptyFunction
             };
         },
@@ -207,6 +208,7 @@ var Npm, Deps, Package, Random, Session, Template, Handlebars, Accounts, Meteor,
         },
         config: emptyFunction,
         urls: {},
+        registerLoginHandler: emptyFunction,
         onCreateUser: emptyFunction,
         loginServiceConfiguration:  new Meteor.Collection('loginserviceconfiguration'),
         validateNewUser: emptyFunction


### PR DESCRIPTION
meteor-stubs.js is currently missing stubs for Meteor.cursor.observe as well as Accounts.registerLoginHandler.
