### PR TITLE
Set src options for jshint in the rtd config file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -373,7 +373,7 @@
             'jshint': {
                 app: {
                     options: rtdConf.options.jshint && rtdConf.options.jshint.appOptions ? rtdConf.options.jshint.appOptions : {},
-                    src: ['<%= basePath %>/app/**/*.js', '!<%= basePath %>/app/.meteor/**/*.js', '!<%= basePath %>/app/packages/**/*.js']
+                    src: ['<%= basePath %>/app/**/*.js', '!<%= basePath %>/app/.meteor/**/*.js', '!<%= basePath %>/app/packages/**/*.js'].concat(rtdConf.options.jshint && rtdConf.options.jshint.src ? rtdConf.options.jshint.src : [])
                 },
                 test: {
                     options: rtdConf.options.jshint && rtdConf.options.jshint.testOptions ? rtdConf.options.jshint.testOptions : {},

--- a/rtd.conf.js
+++ b/rtd.conf.js
@@ -37,13 +37,16 @@ module.exports = {
             // if you want to customize jslint options for app and/or test code, you can do that here
             appOptions: {},
             testOptions: {}
+            // set additional directories to ignore ie:
+            // src: ['!<%= basePath %>/app/client/javascripts/vendor/*.js']
+            src: []
         },
-	    coffeelint: {
-		    enabled: true,
-		    // if you want to customize coffeelint options for app and/or test code, you can do that here
-			appOptions: {},
-	        testOptions: {}
-	    },
+        coffeelint: {
+            enabled: true,
+            // if you want to customize coffeelint options for app and/or test code, you can do that here
+            appOptions: {},
+            testOptions: {}
+        },
         // if you have client libraries, you'll want to exclude them from test coverage
         instrumentationExcludes: ['**/packages/**', '**/3rd/**', 'fixture.js', 'fixture.coffee'],
         // If your dev environment has a stand-alone mongo service, you should disabled this


### PR DESCRIPTION
Provide a way to specify directories for JSHint to ignore from the rtd.config.js file
