### PR TITLE
Update meteor-stubs.js

### DIFF
--- a/lib/meteor-stubs.js
+++ b/lib/meteor-stubs.js
@@ -56,6 +56,7 @@ var Npm, Deps, Package, Random, Session, Template, Handlebars, Accounts, Meteor,
         insert: emptyFunction,
         find: function () {
             return {
+                count: emptyFunction,
                 fetch: emptyFunction,
                 observe: emptyFunction,
                 observeChanges: emptyFunction


### PR DESCRIPTION
Fixes error:

```
TypeError: 'undefined' is not a function (evaluating 'Meteor.users.find().count()')
```
