### PR TITLE
Add missing event to JQuery

### DIFF
--- a/lib/jquery-stubs.js
+++ b/lib/jquery-stubs.js
@@ -18,6 +18,7 @@ var $, jQuery;
         resize: emptyFunction,
         val: emptyFunction,
         live: emptyFunction,
+        slideUp: emptyFunction,
         on: function (eventKey, eventFunction) {
             JQuery.prototype.onEventMap[eventKey] = eventFunction;
 


### PR DESCRIPTION
What is the proper way to extend the rtd JQuery stub with more functions ?
I didn't manage to do so in my `stubs.coffee` file, and I don't think that doing a pull request every time I need a new event is the correct solution.

Also, the errors reported are not easy to understand. For example:

**template**

```
Template.coinsManager.events
  "click #close_donation": (e) ->
    $("#donation_block").slideUp()
```

**test**

  it "hides the donation addresses when clicking on #close_donation", ->
    Template.coinsManager.fireEvent "click #close_donation"

First, my test description is incorrect. All we do here is check that the event is fired, not verifying that **slideUp** is called. Any idea how to verify that?

And if I make a typo like missing "n" at **close_donation**:

```
Template.coinsManager.fireEvent "click #close_donatio"
```

Result:

```
FAILED TESTS:
    ✗ hides the donation addresses when clicking on #close_donation
      PhantomJS 1.9.0 (Linux)
    TypeError: 'undefined' is not a function (evaluating 'TemplateClass.prototype[templateName].eventMap[key]()')
    at http://localhost:9876/base/test/rtd/lib/meteor-stubs.js?1391855864000:146
    at http://localhost:9876/base/test/unit/client/addresses.js?1393212397000:3
    at http://localhost:9876/base/test/rtd/node_modules/mocha/mocha.js?1390426114000:4336
    at http://localhost:9876/base/test/rtd/node_modules/mocha/mocha.js?1390426114000:4724
    at http://localhost:9876/base/test/rtd/node_modules/mocha/mocha.js?1390426114000:4815
    at next (http://localhost:9876/base/test/rtd/node_modules/mocha/mocha.js?1390426114000:4649)
    at http://localhost:9876/base/test/rtd/node_modules/mocha/mocha.js?1390426114000:4659
    at next (http://localhost:9876/base/test/rtd/node_modules/mocha/mocha.js?1390426114000:4597)
    at http://localhost:9876/base/test/rtd/node_modules/mocha/mocha.js?1390426114000:4626
    at timeslice (http://localhost:9876/base/test/rtd/node_modules/mocha/mocha.js?1390426114000:5733)

>> Error: Command failed:
Fatal error: Command failed:
```

Such error makes me believe that **fireEvent** is undefined. Would be great to see the failing code with the typo in it.
