### PR TITLE
Change stubs to cater for "Handlebars" being depreciated in Meteor 8.0

### DIFF
--- a/lib/meteor-stubs.js
+++ b/lib/meteor-stubs.js
@@ -239,4 +239,9 @@ var Npm, Deps, Package, Random, Session, Template, UI, Accounts, Meteor, process
 
 	share = {};
 
+	Email = {};
+
+	EJSON = {
+		stringify: function() {}
+	};
 })();


### PR DESCRIPTION
Meteor 8.0 has depreciated "Handlebars" : https://github.com/meteor/meteor/wiki/Using-Blaze#handlebars-namespace-deprecated

This PR changes the stub accordingly.

It also adds basic stubs for the Meteor Email and EJSON objects.
