### PR TITLE
Changed iron router stub 'before'->'onBeforeAction'

### DIFF
--- a/lib/iron-router-stubs.js
+++ b/lib/iron-router-stubs.js
@@ -10,7 +10,7 @@ var Router, RouteController;
         map: emptyFunction,
         configure: emptyFunction,
         current: emptyFunction,
-        before: emptyFunction
+        onBeforeAction: emptyFunction
     };
 
     RouteController = {


### PR DESCRIPTION
Iron Router changed function name from 'before'->'onBeforeAction' in version 0.7.0

See:
https://github.com/EventedMind/iron-router/commit/98505591e645928cb47d7086119d2260a363c30b#diff-e1bbd4f15e3b63427b4261e05b948ea8

This breaks compatability with code that does not use the new names. The old names will be removed in iron router as well though, in version 1.0.
